### PR TITLE
Update dependency and remove trailing slash from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ plugins: [
         {
             resolve: "gatsby-plugin-piwik-pro",
             options: {
-                containerUrl: "https://<YOUR-SITE>.containers.piwik.pro/",
+                containerUrl: "https://<YOUR-SITE>.containers.piwik.pro",
                 siteId: "<SITE-ID>",
                 enabled: <BOOLEAN> // e.g. process.env.NODE_ENV === "production",
             },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     },
     "homepage": "https://github.com/leevi978/gatsby-plugin-piwik-pro#readme",
     "dependencies": {
-        "@piwikpro/react-piwik-pro": "^0.0.2"
+        "@piwikpro/react-piwik-pro": "^1.1.1"
     }
 }


### PR DESCRIPTION
This PR updates react-piwik-pro to the newest version.

I also found that a double slash was added in my container url, right before the id part. That's why I propose to remove it from the docs.

Thanks for the plugin!